### PR TITLE
Update Together referral links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Tech stack
 
 - [Flux 2](https://www.together.ai/blog/flux-2-multi-reference-image-generation-now-available-on-together-ai) from BFL for the image model
-- [Together AI](https://togetherai.link) for inference
+- [Together AI](https://togetherai.link/?utm_source=easyedit&utm_medium=referral&utm_campaign=example-app) for inference
 - Next.js app router with Tailwind
 - Helicone for observability
 - Plausible for website analytics
@@ -18,5 +18,5 @@
 ## Cloning & running
 
 1. Clone the repo: `git clone https://github.com/Nutlope/easyedit`
-2. Create a `.env.local` file and add your [Together AI API key](https://togetherai.link): `TOGETHER_API_KEY=`
+2. Create a `.env.local` file and add your [Together AI API key](https://togetherai.link/?utm_source=easyedit&utm_medium=referral&utm_campaign=example-app): `TOGETHER_API_KEY=`
 3. Run `npm install` and `npm run dev` to install dependencies and run locally

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -127,7 +127,7 @@ export default function RootLayout({
             </a>{" "}
             on{" "}
             <a
-              href="https://togetherai.link"
+              href="https://togetherai.link/?utm_source=easyedit&utm_medium=referral&utm_campaign=example-app"
               target="_blank"
               className="text-gray-200 underline underline-offset-2"
             >


### PR DESCRIPTION
Updates direct Together AI marketing links to use the repo-specific example-app UTM referral URL.\n\nVerification:\n- Checked direct Together links only; docs/model/API-specific links were left unchanged.\n- Ran direct-link scanner for this repo.\n- Ran git diff --check.